### PR TITLE
Fix W/WD4 topcard display with colors off

### DIFF
--- a/unobot.py
+++ b/unobot.py
@@ -372,6 +372,8 @@ class UnoGame:
             if card in ['W', 'WD4']:
                 ret.append('[%s]' % card)
                 continue
+            if 'W' in card:
+                card = card[0] + '*'
             ret.append('%s[%s]' % (card[0], card[1:]))
         return ' '.join(ret)
 


### PR DESCRIPTION
Now displays wild-type card on top of the discard pile as "*" with colors off, just like with colors on, instead of displaying e.g. "R[WD4]", which looks silly.

Closes #31