### PR TITLE
Remove top card & live players' held cards from new decks

### DIFF
--- a/unobot.py
+++ b/unobot.py
@@ -131,6 +131,7 @@ class UnoGame:
         self.smallestHand = HAND_SIZE
         self.deck = []
         self.startTime = None
+        self.dealt = NO
 
     def join(self, bot, trigger):
         with lock:
@@ -201,6 +202,7 @@ class UnoGame:
             self.topCard = self.get_card()
             while self.topCard in ['W', 'WD4']:
                 self.topCard = self.get_card()
+            self.dealt = YES
             self.currentPlayer = random.randrange(len(self.players))  # issue #6
             self.card_played(bot, self.topCard)
             self.show_on_turn(bot)
@@ -477,10 +479,11 @@ class UnoGame:
 
         new_deck *= 2
 
-        new_deck.remove(self.topCard)
-        for hand in self.players:
-            for card in hand:
-                new_deck.remove(card)
+        if self.dealt:  # don't filter the deck if no cards have been dealt yet
+            new_deck.remove(self.topCard)
+            for hand in self.players:
+                for card in hand:
+                    new_deck.remove(card)
 
         random.shuffle(new_deck)
         random.shuffle(new_deck)

--- a/unobot.py
+++ b/unobot.py
@@ -467,8 +467,7 @@ class UnoGame:
                 self.deck = self.create_deck()
         return ret
 
-    @staticmethod
-    def create_deck():
+    def create_deck(self):
         new_deck = []
         for card in (COLORED_CARD_NUMS + COLORED_CARD_NUMS[1:]):
             for color in CARD_COLORS:
@@ -477,6 +476,12 @@ class UnoGame:
             new_deck.extend([card] * 4)
 
         new_deck *= 2
+
+        new_deck.remove(self.topCard)
+        for hand in self.players:
+            for card in hand:
+                new_deck.remove(card)
+
         random.shuffle(new_deck)
         random.shuffle(new_deck)
         return new_deck


### PR DESCRIPTION
Also removing dead players' cards could result in very skewed card distributions if a lot of players have joined and then left the game. Might handle that by storing the number of cards a player has upon leaving, rather than the actual cards held...

For that reason, this isn't necessarily ready to merge yet.