### PR TITLE
Reneging enforcement

### DIFF
--- a/unobot.py
+++ b/unobot.py
@@ -270,8 +270,8 @@ class UnoGame:
                 bot.notice(STRINGS['DRAWN_ALREADY'],
                            self.playerOrder[self.currentPlayer])
                 return
-            self.drawn = YES
             c = self.get_card()
+            self.drawn = c
             self.players[self.playerOrder[self.currentPlayer]].append(c)
         bot.notice(STRINGS['DRAWN_CARD'] % self.render_cards(bot, [c], trigger.nick), trigger.nick)
 
@@ -426,6 +426,8 @@ class UnoGame:
         return bold + ''.join(ret) + CONTROL_NORMAL
 
     def card_playable(self, card):
+        if self.drawn and card != self.drawn:
+            return False
         if 'W' in card and card[0] in CARD_COLORS:
             return True
         with lock:

--- a/unobot.py
+++ b/unobot.py
@@ -427,7 +427,10 @@ class UnoGame:
 
     def card_playable(self, card):
         if self.drawn and card != self.drawn:
-            return False
+            if card[1:] == self.drawn:
+                pass
+            else:
+                return False
         if 'W' in card and card[0] in CARD_COLORS:
             return True
         with lock:

--- a/unobot.py
+++ b/unobot.py
@@ -430,9 +430,9 @@ class UnoGame:
             if card[1:] == self.drawn:
                 pass
             else:
-                return False
+                return NO
         if 'W' in card and card[0] in CARD_COLORS:
-            return True
+            return YES
         with lock:
             if 'W' in self.topCard:
                 return card[0] == self.topCard[0]


### PR DESCRIPTION
Don't allow players who have drawn on the current turn to play any other card.

This does not (yet) output a special message telling a player who tries to renege why they aren't allowed to play a different card.