### PR TITLE
Replace deprecated except syntax ("," --> "as")

### DIFF
--- a/unobot.py
+++ b/unobot.py
@@ -694,7 +694,7 @@ class UnoBot:
                 bot.say(STRINGS['GAINS'] % (winner, score, 'point' if score == 1 else 'points'))
                 self.update_scores(bot, game.players.keys(), winner, score,
                                    (datetime.now() - game.startTime).seconds)
-            except Exception, e:
+            except Exception as e:
                 bot.say("UNO score error: %s" % e)
             del self.games[trigger.sender]
 
@@ -713,7 +713,7 @@ class UnoBot:
             try:
                 with open(self.scoreFile, 'w+') as scorefile:
                     json.dump(scores, scorefile)
-            except Exception, e:
+            except Exception as e:
                 bot.say("Error saving UNO score file: %s" % e)
 
     def get_scores(self, bot):
@@ -728,7 +728,7 @@ class UnoBot:
                     return self.get_scores(bot)
                 except ValueError:
                     bot.say("Something has gone horribly wrong with the UNO scores. Please submit an issue on GitHub.")
-            except IOError, e:
+            except IOError as e:
                 bot.say("Error opening UNO scores: %s" % e)
         return scores
 
@@ -749,7 +749,7 @@ class UnoBot:
                             'points':   int(tokens[3]),
                             'playtime': int(tokens[4]),
                         }
-            except Exception, e:
+            except Exception as e:
                 bot.say("Score conversion error: %s" % e)
                 return
             else:
@@ -757,7 +757,7 @@ class UnoBot:
             try:
                 with open(self.scoreFile, 'w+') as scorefile:
                     json.dump(scores, scorefile)
-            except Exception, e:
+            except Exception as e:
                 bot.say("Error converting UNO score file: %s" % e)
             else:
                 bot.say("Wrote UNO score file in new JSON format.")


### PR DESCRIPTION
Python 3 does not support "except Exception, e". Replace uses of it with the construct "except Exception as e", which is supported in both Python 3 and in Python 2.6+ (I don't intend to support any versions below 2.7 anyway).

As of issue creation, the code audit is incomplete, but most of the issues should be covered already.

Reference #44, #46.