### PR TITLE
`.unostop` any channel if admin

### DIFF
--- a/unobot.py
+++ b/unobot.py
@@ -579,14 +579,15 @@ class UnoBot:
             bot.say(STRINGS['GAME_STARTED'] % self.games[trigger.sender].owner)
 
     def stop(self, bot, trigger, forced=NO):
-        if trigger.sender not in self.games:
+        chan = tools.Identifier(trigger.group(3) or trigger.sender)
+        if chan not in self.games:
             bot.notice(STRINGS['NOT_STARTED'], trigger.nick)
             return
-        game = self.games[trigger.sender]
+        game = self.games[chan]
         if trigger.nick == game.owner or trigger.admin or forced:
             if not forced:
                 bot.say(STRINGS['GAME_STOPPED'])
-            del self.games[trigger.sender]
+            del self.games[chan]
         else:
             bot.say(STRINGS['CANT_STOP'] % game.owner)
 

--- a/unobot.py
+++ b/unobot.py
@@ -41,6 +41,7 @@ lock = threading.RLock()
 STRINGS = {
     'GAME_STARTED':    "IRC-UNO started by %s - Type join to join!",
     'GAME_STOPPED':    "Game stopped.",
+    'REMOTE_STOP':     "Game stopped in %s by %s.",
     'CANT_STOP':       "%s is the game owner, you can't stop it!",
     'DEALING_IN':      "Dealing %s into the game as player #%s!",
     'DEALING_BACK':    "Here, %s, I saved your cards. You're back in the game as player #%s.",
@@ -587,6 +588,8 @@ class UnoBot:
         if trigger.nick == game.owner or trigger.admin or forced:
             if not forced:
                 bot.say(STRINGS['GAME_STOPPED'])
+                if trigger.sender != chan:
+                    bot.say(STRINGS['REMOTE_STOP'] % (trigger.sender, trigger.nick), chan)
             del self.games[chan]
         else:
             bot.say(STRINGS['CANT_STOP'] % game.owner)


### PR DESCRIPTION
Allows admins (or the game owner, technically) to stop a game in another channel, without having to switch to that channel.

Questionably useful, but I tried to do it thinking this feature already existed, so...